### PR TITLE
Added short arguments to help with proxy loading.

### DIFF
--- a/Code/Logic/GameServer.cs
+++ b/Code/Logic/GameServer.cs
@@ -172,11 +172,14 @@ namespace L2_login
                         Globals.pre_useGameServerOveride = true;
                         Globals.pre_checkAdvancedSettings = true;
                         break;
+
+                    case "-upl":
                     case "-useproxylogin":
                         Globals.pre_useProxyServerForLogin = true;
                         Globals.pre_checkAdvancedSettings = true;
                         break;
 
+                    case "-upg":
                     case "-useproxygame":
                         Globals.pre_useProxyServerForGameserver = true;
                         Globals.pre_checkAdvancedSettings = true;
@@ -188,18 +191,27 @@ namespace L2_login
                     case "-gameserverport":
                         Globals.pre_gameserver_override_port = data;
                         break;
+
+                    case "-s5ip":
                     case "-socks5ip":
                         Globals.pre_socks5_ip = data;
                         break;
+
+                    case "-s5po":
                     case "-socks5port":
                         Globals.pre_socks5_port = data;
                         break;
+
+                    case "-s5us":
                     case "-socks5username":
                         Globals.pre_socks5_username = data;
                         break;
+
+                    case "-s5pa":
                     case "-socks5password":
                         Globals.pre_socks5_password = data;
                         break;
+                        
                     case "-ew":
                     case "-enterworld":
                         Globals.pre_EnterWorldCheckbox = true;

--- a/bin/latest/build/commands.txt
+++ b/bin/latest/build/commands.txt
@@ -131,6 +131,7 @@ double click in inventory to use items
 -x:data IG local listen port
 -y:data IG local listen ip
 -z:# Chronicle to use (7 = CT1)(8 = CT1.5)(9 = CT2.1)(10 = CT2.2)
+-o: -options: load options file
 
 -accept (same as -a)
 -blowfish (same as -b)
@@ -147,14 +148,14 @@ double click in inventory to use items
 The following command line parameters require valid keys to function:
 
 -overidegameserver enables the gameserver overide 
--useproxylogin enables proxy server for login connections 
--useproxygame enables proxy server for game connections 
+-upl -useproxylogin enables proxy server for login connections 
+-upg -useproxygame enables proxy server for game connections 
 -gameserverip ip address of gameserver 
 -gameserverport port of gameserver 
--socks5ip ip address of the socks proxy server 
--socks5port port of the socks proxy server 
--socks5username username for socks proxy 
--socks5password password for socks proxy
+-s5ip -socks5ip ip address of the socks proxy server 
+-s5po -socks5port port of the socks proxy server 
+-s5us -socks5username username for socks proxy 
+-s5pa -socks5password password for socks proxy
 -ewip enable editing ip in enterworld packet
 -ip01: , -ip02: , -ip03: ,ip04:
 -ip11: , -ip12: , -ip13: ,ip14:

--- a/bin/latest/build/config/loginlist.txt
+++ b/bin/latest/build/config/loginlist.txt
@@ -1,2 +1,2 @@
-servername
-servername.com
+L2Toggle.com
+51.255.80.112


### PR DESCRIPTION
If You want to do options, script, server, account, password and proxy with logins You might run into max character limit for windows shortcut like I did. So I added short arguments in light of Your -o example.

Also added L2Toggle to loginlist if You don't mind.